### PR TITLE
Fix: Update Netty to resolve high security alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <projectreactor.version>2022.0.8</projectreactor.version>
         <javax.mail.version>1.6.2</javax.mail.version>
         <commons-cli.version>1.5.0</commons-cli.version>
-        <netty-handler.version>4.1.94.Final</netty-handler.version>
+        <netty.version>4.1.130.Final</netty.version>
         <javax.mail.version>1.6.2</javax.mail.version>
     </properties>
 
@@ -40,6 +40,21 @@
                 <version>${projectreactor.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -112,7 +127,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty-handler.version}</version>
+            <version>${netty.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Changes

Updates all Netty dependencies to 4.1.130.Final to resolve Dependabot security alerts.

### Dependencies updated
| Package | Before | After | Severity |
|---------|--------|-------|----------|
| `io.netty:netty-handler` | 4.1.94.Final | **4.1.130.Final** | HIGH (3 alerts) |
| `io.netty:netty-codec-http2` | ~4.1.94 (transitive) | **4.1.130.Final** | HIGH |
| `io.netty:netty-codec-http` | ~4.1.94 (transitive) | **4.1.130.Final** | MODERATE |

### Approach
- Renamed property `netty-handler.version` → `netty.version` (single version for all netty artifacts)
- Added `dependencyManagement` entries for `netty-codec-http2`, `netty-codec-http`, and `netty-handler` to override transitive versions from the AWS SDK BOM
- XML validated successfully

### Note
Maven build could not be run in this environment (no Maven installed), but the XML is well-formed and the dependency coordinates are correct.